### PR TITLE
Add filter to add extra responsive class

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -67,6 +67,15 @@ add_filter('wpcf7_form_elements', function ($content) {
 });
 
 /**
+ * Make post images responsive (again?)
+ */
+add_filter('get_image_tag_class','indahouse_add_image_class');
+function indahouse_add_image_class ($class){
+    $class .= ' img-fluid';
+    return $class;
+}
+
+/**
  * Remove old jQuery version from non-admin pages to
  */
 if ( !is_admin() ) wp_deregister_script('jquery');


### PR DESCRIPTION
Fixes #14 

Solution based on: https://wordpress.stackexchange.com/questions/302130/how-to-add-css-class-to-image-attached-in-all-the-posts